### PR TITLE
Nova opção PadronizarNomes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.vshistory/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/OpenAC.Net.DFe.Core/Common/DFeArquivosConfigBase.cs
+++ b/src/OpenAC.Net.DFe.Core/Common/DFeArquivosConfigBase.cs
@@ -120,6 +120,14 @@ public abstract class DFeArquivosConfigBase
     public bool Salvar { get; set; }
 
     /// <summary>
+    /// Define se os nomes dos arquivos devem ser padronizados,
+    /// utilizando a chave da NFSe, Id do DPS ou NSU, conforme o tipo de operação.
+    /// Quando <c>false</c>, utiliza o comportamento padrão da biblioteca,
+    /// cujo formato pode variar e não segue um padrão fixo.
+    /// </summary>
+    public bool PadronizarNomes { get; set; }
+
+    /// <summary>
     /// Define/retorna se deve ser adicionado um literal ao caminho de salvamento.
     /// </summary>
     public bool AdicionarLiteral { get; set; }

--- a/src/OpenAC.Net.DFe.Core/Extensions/DFeExtensions.cs
+++ b/src/OpenAC.Net.DFe.Core/Extensions/DFeExtensions.cs
@@ -39,7 +39,7 @@ using OpenAC.Net.Core.Extensions;
 
 namespace OpenAC.Net.DFe.Core.Extensions;
 
-internal static class DFeExtensions
+public static class DFeExtensions
 {
     public static DFeBaseAttribute GetElementAtt(this PropertyInfo prop)
     {
@@ -153,5 +153,19 @@ internal static class DFeExtensions
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Formata uma string numérica com zeros à esquerda.
+    /// </summary>
+    /// <param name="value">String numérica</param>
+    public static string FillZeros(this string? value, int tamanho = 6, string fallback = "000000")
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return fallback;
+
+        return int.TryParse(value, out var numero)
+            ? numero.ToString(new string('0', tamanho))
+            : fallback;
     }
 }


### PR DESCRIPTION
Nova opção PadronizarNomes (false por padrão), que define se os nomes dos arquivos devem ser padronizados e consistentes. Quando desabilitada, o padrão atual é mantido, com a correção de que os números agora são gerados com zeros à esquerda conforme esperado (o código anterior não aplicava corretamente essa formatação).