### PR TITLE
fix: Prevenir a criação de instância vazia nos objetos de documento fiscal quando uma tag estiver ausênte

### DIFF
--- a/src/OpenAC.Net.DFe.Core.Tests/ClassTypeDeserializationTest.cs
+++ b/src/OpenAC.Net.DFe.Core.Tests/ClassTypeDeserializationTest.cs
@@ -1,0 +1,43 @@
+using OpenAC.Net.DFe.Core.Tests.Commom;
+
+namespace OpenAC.Net.DFe.Core.Tests
+{
+    public class ClassTypeDeserializationTest
+    {
+        /// <summary>
+        /// Valida que a ausência de uma tag XML opcional mantém a propriedade nula no objeto deserializado.
+        /// </summary>
+        [Fact]
+        public void DeserializarXmlSemTagOpcional_DeveManterPropriedadeComoNull()
+        {
+            var xml = @"<RootTest><RequiredChild>Valor</RequiredChild></RootTest>";
+
+            var result = TestDFeDocument.Load(xml);
+
+            Assert.NotNull(result);
+            Assert.Equal("Valor", result.RequiredChild);
+            Assert.Null(result.OptionalChildClass);
+        }
+
+        /// <summary>
+        /// Valida que a presença de uma tag XML opcional instancia e preenche a propriedade corretamente.
+        /// </summary>
+        [Fact]
+        public void DeserializarXmlComTagOpcional_DeveInstanciarEPreencherPropriedade()
+        {
+            var xml = @"<RootTest>
+                            <RequiredChild>Valor</RequiredChild>
+                            <OptionalChildClass>
+                                <Value>Teste</Value>
+                            </OptionalChildClass>
+                        </RootTest>";
+
+            var result = TestDFeDocument.Load(xml);
+
+            Assert.NotNull(result);
+            Assert.Equal("Valor", result.RequiredChild);
+            Assert.NotNull(result.OptionalChildClass);
+            Assert.Equal("Teste", result.OptionalChildClass.Value);
+        }
+    }
+}

--- a/src/OpenAC.Net.DFe.Core.Tests/Commom/TestDFeDocument.cs
+++ b/src/OpenAC.Net.DFe.Core.Tests/Commom/TestDFeDocument.cs
@@ -1,0 +1,21 @@
+using OpenAC.Net.DFe.Core.Attributes;
+using OpenAC.Net.DFe.Core.Document;
+
+namespace OpenAC.Net.DFe.Core.Tests.Commom
+{
+    [DFeRoot("RootTest")]
+    public class TestDFeDocument : DFeDocument<TestDFeDocument>
+    {
+        [DFeElement("RequiredChild", Ocorrencia = Ocorrencia.Obrigatoria)]
+        public string RequiredChild { get; set; } = string.Empty;
+
+        [DFeElement("OptionalChildClass", Ocorrencia = Ocorrencia.NaoObrigatoria)]
+        public OptionalClassModel? OptionalChildClass { get; set; }
+    }
+
+    public class OptionalClassModel
+    {
+        [DFeElement("Value", Ocorrencia = Ocorrencia.Obrigatoria)]
+        public string Value { get; set; } = string.Empty;
+    }
+}

--- a/src/OpenAC.Net.DFe.Core/Serializer/ObjectSerializer.cs
+++ b/src/OpenAC.Net.DFe.Core/Serializer/ObjectSerializer.cs
@@ -156,8 +156,9 @@ internal class ObjectSerializer
     {
         try
         {
+            if (element == null) return null; // Se o elemento XML é nulo, o objeto deserializado deve ser nulo
+
             var ret = type.HasCreate() ? type.GetCreate().Invoke() : Activator.CreateInstance(type);
-            if (element == null) return ret;
 
             var properties = type.GetProperties();
             foreach (var prop in properties)


### PR DESCRIPTION
## O que foi feito?
- Adicionado early return `if (element == null) return null;` no `ObjectSerializer.Deserialize`.

## Motivação
- Garantir que tags XML ausentes em documentos DF-e resultem em instâncias `null`, refletindo corretamente a ausência de grupos opcionais e evitando a criação de objetos vazios desnecessários.

## Exemplo de comportamento

Utilizando a biblioteca `OpenAC.Net.NFSe.Nacional`, considere um documento DPS que **não possui a tag de substituição** no XML de entrada.

### Antes da alteração

Quando o XML era desserializado, a ausência da tag de substituição resultava na criação de uma instância vazia do objeto correspondente.

```csharp
var meuXml = "..."; // XML sem tag de substituição

var dps = Dps.Load(meuXml);
// Objeto de substituição instanciado na DPS,
// com chave preenchida com string vazia
// e motivo preenchido com o valor default.

var xml = Dps.GetXml();
// XML com a tag de substituição preenchida,
// apesar de ela não existir no XML original.
```

Esse comportamento fazia com que a desserialização alterasse semanticamente o documento: um grupo que originalmente **não existia** passava a ser representado por um objeto vazio e, posteriormente, era serializado novamente.

### Após a alteração

Com o `early return` adicionado ao `ObjectSerializer.Deserialize`, elementos XML ausentes passam a resultar em `null`.

```csharp
var meuXml = "..."; // XML sem tag de substituição

var dps = Dps.Load(meuXml);
// Objeto de substituição nulo.

service.Enviar(dps);

var xml = Dps.GetXml();
// XML sem a tag de substituição,
// preservando o conteúdo original.
```

Dessa forma, a ausência de um grupo opcional no XML é preservada durante o ciclo de desserialização e serialização.

## Análise de Impacto Técnico

### 1. Semântica de Deserialização para Documentos Fiscais (DF-e)
* **Comportamento Anterior:** Quando um elemento/tag XML opcional não estava presente no documento, o deserializador instanciava um objeto vazio (`Activator.CreateInstance` ou `GetCreate().Invoke()`) e o atribuía à propriedade correspondente.
* **Novo Comportamento:** Quando a tag XML estiver ausente, o método retorna `null`, refletindo fielmente a ausência do grupo de informação no XML.

### 2. Atenção para Código Consumidor (Risco de Quebra)
* **Risco (Baixo/Médio):** Códigos consumidores que acessavam propriedades de grupos opcionais sem checagem de nulo (assumindo que seriam instâncias vazias não-nulas) podem necessitar de verificação de nulo (`?.`) caso a tag XML esteja ausente.
