### PR TITLE
fix: Correções de Testes Unitários em SerializerTest

### DIFF
--- a/src/OpenAC.Net.DFe.Core.Tests/SerializerTest.cs
+++ b/src/OpenAC.Net.DFe.Core.Tests/SerializerTest.cs
@@ -19,10 +19,8 @@ namespace OpenAC.Net.DFe.Core.Tests
                 TesteEnum1 = TesteEnum.Value1,
                 TesteEnum2 = null,
                 TestNullInt = 999,
-                TestDateTz = new DateTimeOffset(DateTime.Now, TimeSpan.FromHours(-4))
+                TestDateTz = new DateTimeOffset(DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified), TimeSpan.FromHours(-4))
             };
-
-            var cdata = File.ReadAllText("cdata_teste.xml");
 
             for (var i = 0; i < 3; i++)
             {
@@ -30,7 +28,7 @@ namespace OpenAC.Net.DFe.Core.Tests
                 {
                     Id = i + 1,
                     TestDecimal = xml.TestDecimal + i + 1.000M,
-                    TestString = $"<![CDATA[{cdata}]]>"
+                    TestString = $"<![CDATA[Pedido #1234. Entregar p/ João & Maria. Obs: Se < 18 anos, retirar com responsável.]]>"
                 };
                 xml.XmlItems.Add(item);
             }


### PR DESCRIPTION
- **Correção no `TestDateTz`:** Ajustada a criação do `DateTimeOffset` utilizando
`DateTimeKind.Unspecified`. Isso corrige a exceção `System.ArgumentException: The UTC Offset of the
local dateTime parameter does not match the offset argument`, que ocorria quando o fuso horário da
máquina local não coincidia com o offset estipulado no teste (`-04:00`).
- **Fix no Teste de CDATA:** Removida a dependência do arquivo `cdata_teste.xml` (inexistente no
repositório), substituindo a leitura por uma string CDATA inline para viabilizar a execução dos testes
sem dependências externas ausentes.